### PR TITLE
fix: start server only when run directly

### DIFF
--- a/sample-app/src/server.js
+++ b/sample-app/src/server.js
@@ -62,9 +62,11 @@ app.use((err, req, res, next) => {
 });
 
 // Start server
-app.listen(PORT, () => {
-  console.log(`Server is running on http://localhost:${PORT}`);
-  console.log(`Environment: ${process.env.NODE_ENV || 'development'}`);
-});
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Server is running on http://localhost:${PORT}`);
+    console.log(`Environment: ${process.env.NODE_ENV || 'development'}`);
+  });
+}
 
 module.exports = app;


### PR DESCRIPTION
## Description

Wrapped ```app.listen``` in a ```require.main === module]``` check so the server only starts when run directly, not when imported for testing. This prevents Jest from hanging after tests complete.

## Fixes 
[BUG] - Jest does not exit after test run completes  : https://github.com/nisalgunawardhana/github-actions-learning/issues/47

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Code refactor (no functional changes)
- [ ] 🚀 Performance improvement
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?

- [ ] Added/updated unit tests
- [ ] Added/updated integration tests
- [x] Tested manually on local machine
- [ ] Tested in staging environment

**Test Configuration:**
- Node.js version: v22.18.0
- OS: Windows

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests passed locally with my changes
- [x] Any dependent changes have been merged and published

## Screenshots or Workflow Logs

### Before Change
<img width="1176" height="1167" alt="image" src="https://github.com/user-attachments/assets/54833dd0-7083-46c0-8915-1f9da9706e88" />

### After Change
<img width="1222" height="742" alt="image" src="https://github.com/user-attachments/assets/45f5d961-6ff3-41e8-bbb4-57c9dfd0a360" />

## Additional Context

N/A

